### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Implementing the detection of single, double and long button pressing.
 category=Device Control
 url=https://github.com/slavaza/SuperButton
 architectures=*
-includes=SuperButton.h
+includes=SuperButton.hpp


### PR DESCRIPTION
The previous includes value: SuperButton.h was incorrect since the library does not contain a file of that name.